### PR TITLE
Rudimentary stack profiler

### DIFF
--- a/cmd/jsonnet/cmd.go
+++ b/cmd/jsonnet/cmd.go
@@ -397,6 +397,9 @@ func main() {
 	cmd.StartCPUProfile()
 	defer cmd.StopCPUProfile()
 
+	jsonnet.StartStackProfile()
+	defer jsonnet.StopStackProfile()
+
 	vm := jsonnet.MakeVM()
 	vm.ErrorFormatter.SetColorFormatter(color.New(color.FgRed).Fprintf)
 

--- a/interpreter.go
+++ b/interpreter.go
@@ -17,13 +17,18 @@ limitations under the License.
 package jsonnet
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"io"
+	"log"
 	"math"
+	"math/rand"
+	"os"
 	"reflect"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/google/go-jsonnet/ast"
 	"github.com/google/go-jsonnet/astgen"
@@ -968,7 +973,45 @@ func jsonToValue(i *interpreter, v interface{}) (value, error) {
 	}
 }
 
+var (
+	stackProfileOut   *bufio.Writer
+	stackProfileRatio = 0.01
+)
+
+func StartStackProfile() {
+	var err error
+
+	if os.Getenv("JSONNET_STACK_PROFILE") != "" {
+		stackProfileOutFile, err := os.Create(os.Getenv("JSONNET_STACK_PROFILE"))
+		if err != nil {
+			log.Fatal("could not create stack profile: ", err)
+		}
+		stackProfileOut = bufio.NewWriter(stackProfileOutFile)
+	}
+
+	if os.Getenv("JSONNET_STACK_PROFILE_RATIO") != "" {
+		stackProfileRatio, err = strconv.ParseFloat(os.Getenv("JSONNET_STACK_PROFILE_RATIO"), 64)
+		if err != nil {
+			log.Fatal("could not parse stack profile ratio: ", err)
+		}
+	}
+}
+
+func StopStackProfile() {
+	if stackProfileOut != nil {
+		stackProfileOut.Flush()
+	}
+}
+
 func (i *interpreter) EvalInCleanEnv(env *environment, ast ast.Node, trimmable bool) (value, error) {
+	if stackProfileOut != nil && rand.Float64() < stackProfileRatio {
+		stack := []string{}
+		for _, frame := range i.getCurrentStackTrace() {
+			stack = append(stack, frame.Loc.String()+":"+frame.Name)
+		}
+		fmt.Fprintln(stackProfileOut, strings.Join(stack, ";")+" 1")
+	}
+
 	err := i.newCall(*env, trimmable)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Usage:

  JSONNET_STACK_PROFILE=stacks.out jsonnet main.jsonnet
  cat stacks.out | flamegraph.pl --hash > flamegraph.svg

https://github.com/google/go-jsonnet/pull/529

Todo:

> There's plenty of room for improvement:

>    Making the code nicer
>    Including a time component (since we currently assume each eval takes a fixed amount of time)
>    Buffering stacks in memory with their counts and writing out aggregated counts in the end


> This is very interesting. I was thinking about doing something like that myself, but didn't have much time recently.
> I'd like to refactor it slightly (eliminate globals, extract all profiling logic to a separate function, so that in the normal flow it's just one check and one function call). Otherwise it looks good.